### PR TITLE
[NodeAnalyzer] Fix error BetterNodeFinder->findParentTypes() not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "rector/rector-phpunit": "^0.11"
     },
     "require-dev": {
-        "rector/rector-src": "dev-main#1045471",
+        "rector/rector-src": "dev-main",
         "phpunit/phpunit": "^9.5",
         "symplify/phpstan-rules": "^9.4",
         "symplify/phpstan-extensions": "^9.4",

--- a/src/NodeAnalyzer/TemplatePropertyAssignCollector.php
+++ b/src/NodeAnalyzer/TemplatePropertyAssignCollector.php
@@ -66,7 +66,7 @@ final class TemplatePropertyAssignCollector
     }
 
     /**
-     * @return Node[] $foundParent
+     * @return Node[]
      */
     private function getFoundParents(PropertyFetch $propertyFetch): array
     {


### PR DESCRIPTION
Fix `BetterNodeFinder->findParentTypes()` not found, need to loop as `ScopeNestingComparator->isInBothIfElseBranch` pass a single `Node` in first parameter.