### PR TITLE
[PostRector] Using NodesToAddCollector on rector rules

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -74,3 +74,8 @@ parameters:
 
         # complex logic
         - '#Cognitive complexity for "Rector\\Nette\\NodeAnalyzer\\TemplatePropertyAssignCollector\:\:processAssign\(\)" is \d+, keep it under 9#'
+
+        -
+            message: '#Unreachable statement \- code above always terminates#'
+            paths:
+                - src/NodeResolver/FormVariableInputNameTypeResolver.php

--- a/src/Rector/ClassMethod/TranslateClassMethodToVariadicsRector.php
+++ b/src/Rector/ClassMethod/TranslateClassMethodToVariadicsRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
 
             $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
             $positionNode = $currentStmt ?? $node;
-            $this->addNodeBeforeNode($assign, $positionNode);
+            $this->nodesToAddCollector->addNodeBeforeNode($assign, $positionNode);
 
             return NodeTraverser::STOP_TRAVERSAL;
         });

--- a/src/Rector/MethodCall/AddNextrasDatePickerToDateControlRector.php
+++ b/src/Rector/MethodCall/AddNextrasDatePickerToDateControlRector.php
@@ -93,7 +93,7 @@ CODE_SAMPLE
 
             // this fixes printing indent
             $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-            $this->addNodeBeforeNode($assign, $node);
+            $this->nodesToAddCollector->addNodeBeforeNode($assign, $node);
 
             return $node;
         }


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector-src/pull/812 as this direct call is deprecated.  I tried to follow return array of nodes of https://tomasvotruba.com/blog/how-to-replace-single-node-with-two-nodes-in-abstract-syntax-tree/ and seems failure on assign and method call:

```php
            return [
                new Expression($assign),
                new Expression($node)
            ];
```

It got error:

```bash
Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\AddNextrasDatePickerToDateControlRectorTest::test with data set #3 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
LogicException: leaveNode() may only return an array if the parent structure is an array
```

so use `NodesToAddCollector` property for now.