### PR TITLE
Fixing test neon renamemethod

### DIFF
--- a/src/Rector/Neon/RenameMethodNeonRector.php
+++ b/src/Rector/Neon/RenameMethodNeonRector.php
@@ -35,10 +35,10 @@ CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 services:
-    -
-        class: SomeClass
-        setup:
-            - newCall
+-
+    class: SomeClass
+    setup:
+        - newCall
 CODE_SAMPLE
             ),
         ]);

--- a/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service-as-class.neon
+++ b/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service-as-class.neon
@@ -5,7 +5,7 @@ services:
             - add('first-key', 'first-value')
 -----
 services:
-    -
-        class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
-        setup:
-            - addConfig('first-key', 'first-value')
+-
+    class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
+    setup:
+        - addConfig('first-key', 'first-value')

--- a/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service-as-factory.neon
+++ b/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service-as-factory.neon
@@ -6,8 +6,8 @@ services:
             - add('second-key', 'second-value')
 -----
 services:
-    -
-        factory: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
-        setup:
-            - addConfig('first-key', 'first-value')
-            - addConfig('second-key', 'second-value')
+-
+    factory: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
+    setup:
+        - addConfig('first-key', 'first-value')
+        - addConfig('second-key', 'second-value')

--- a/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service_as_class_with_tabs.neon
+++ b/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service_as_class_with_tabs.neon
@@ -5,7 +5,7 @@ services:
 			- add('second-key', 'second-value')
 -----
 services:
-	-
-		class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
-		setup:
-			- addConfig('second-key', 'second-value')
+-
+	class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService('service-name')
+	setup:
+		- addConfig('second-key', 'second-value')

--- a/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service_without_parameter.neon
+++ b/tests/Rector/Neon/RenameMethodNeonRector/Fixture/service_without_parameter.neon
@@ -5,7 +5,7 @@ services:
             - add('first-key', 'first-value')
 -----
 services:
-    -
-        class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService
-        setup:
-            - addConfig('first-key', 'first-value')
+-
+    class: Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\Source\SecondService
+    setup:
+        - addConfig('first-key', 'first-value')


### PR DESCRIPTION
@TomasVotruba it seems on latest CI run, the test indentation seems removed after services new line. This remove the indentation so the CI will be green.