### PR TITLE
[Nette] Using NodeTypeResolver->getType() instead of deprecated getObjectType()

### DIFF
--- a/src/Kdyby/ValueObject/VariableWithType.php
+++ b/src/Kdyby/ValueObject/VariableWithType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Nette\Kdyby\ValueObject;
 
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -14,7 +15,7 @@ use PHPStan\Type\Type;
 final class VariableWithType
 {
     /**
-     * @param Identifier|Name|NullableType|UnionType|null $phpParserTypeNode
+     * @param ComplexType|Identifier|Name|NullableType|UnionType|null $phpParserTypeNode
      */
     public function __construct(
         private string $name,
@@ -34,7 +35,7 @@ final class VariableWithType
     }
 
     /**
-     * @return Identifier|Name|NullableType|UnionType|null
+     * @return ComplexType|Identifier|Name|NullableType|UnionType|null
      */
     public function getPhpParserTypeNode(): ?Node
     {

--- a/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
+++ b/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
@@ -121,7 +121,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $nodeVar = $this->getObjectType($node->var);
+        $nodeVar = $this->nodeTypeResolver->getType($node->var);
         if (! $nodeVar instanceof MixedType) {
             return null;
         }


### PR DESCRIPTION
The `getObjectType()` is deprecated at rector-src's AbstractRector

https://github.com/rectorphp/rector-src/blob/c6473c6a0b4ecaab710353e83f0c740e2e998d26/src/Rector/AbstractRector.php#L335-L338

This PR update to use NodeTypeResolver->getType()