### PR TITLE
[FileProcessor] Fix return array on FileProcessors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -114,3 +114,10 @@ parameters:
 
         # fixed in dev-main symplify
         - '#Do not use chained method calls\. Put each on separated lines#'
+
+
+        -
+             message: '#Instead of array shape, use value object with specific types in constructor and getters#'
+             paths:
+                 - src/FileProcessor/LatteFileProcessor.php
+                 - src/FileProcessor/NeonFileProcessor.php

--- a/src/FileProcessor/LatteFileProcessor.php
+++ b/src/FileProcessor/LatteFileProcessor.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\Nette\FileProcessor;
 
+use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
-use Rector\Nette\Contract\Rector\LatteRectorInterface;
 use Rector\Core\ValueObject\Error\SystemError;
 use Rector\Core\ValueObject\Reporting\FileDiff;
+use Rector\Nette\Contract\Rector\LatteRectorInterface;
 use Rector\Parallel\ValueObject\Bridge;
-use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 
 final class LatteFileProcessor implements FileProcessorInterface
 {

--- a/src/FileProcessor/NeonFileProcessor.php
+++ b/src/FileProcessor/NeonFileProcessor.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Rector\Nette\FileProcessor;
 
+use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\ValueObject\Application\File;
 use Rector\Core\ValueObject\Configuration;
+use Rector\Core\ValueObject\Error\SystemError;
+use Rector\Core\ValueObject\Reporting\FileDiff;
 use Rector\Nette\Contract\Rector\NeonRectorInterface;
 use Rector\Nette\NeonParser\NeonNodeTraverserFactory;
 use Rector\Nette\NeonParser\NeonParser;
 use Rector\Nette\NeonParser\Printer\FormatPreservingNeonPrinter;
-use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
-use Rector\Core\ValueObject\Error\SystemError;
-use Rector\Core\ValueObject\Reporting\FileDiff;
 use Rector\Parallel\ValueObject\Bridge;
 
 final class NeonFileProcessor implements FileProcessorInterface

--- a/src/FileProcessor/NeonFileProcessor.php
+++ b/src/FileProcessor/NeonFileProcessor.php
@@ -65,7 +65,7 @@ final class NeonFileProcessor implements FileProcessorInterface
 
         $file->changeFileContent($changedFileContent);
 
-        $fileDiff = $this->fileDiffFactory->createFileDiff($file, $fileContent, $changedFileContent);
+        $fileDiff = $this->fileDiffFactory->createFileDiff($file, $originalPrintedContent, $changedFileContent);
         $systemErrorsAndFileDiffs[Bridge::FILE_DIFFS][] = $fileDiff;
 
         return $systemErrorsAndFileDiffs;


### PR DESCRIPTION
@TomasVotruba this is based on error https://github.com/rectorphp/rector-src/runs/4649685575?check_suite_focus=true#step:14:81 , I tried to apply the changes of return of FIle processor return on `LatteFileProcessor` and `NeonFileProcessor`