### PR TITLE
[ComponentModel] Add #[\ReturnTypeWillChange] on Component stubs

### DIFF
--- a/stubs/Nette/ComponentModel/Component.php
+++ b/stubs/Nette/ComponentModel/Component.php
@@ -10,21 +10,25 @@ if (class_exists('Nette\ComponentModel\Component')) {
 
 class Component extends Container implements \ArrayAccess
 {
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
 
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
 
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
 
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
 


### PR DESCRIPTION
Avoid the following error on PHPUnit:

```bash
PHP Deprecated:  Return type of Nette\ComponentModel\Component::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 13
PHP Deprecated:  Return type of Nette\ComponentModel\Component::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 18
PHP Deprecated:  Return type of Nette\ComponentModel\Component::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 23
PHP Deprecated:  Return type of Nette\ComponentModel\Component::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 28
.
Deprecated: Return type of Nette\ComponentModel\Component::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 13

Deprecated: Return type of Nette\ComponentModel\Component::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 18

Deprecated: Return type of Nette\ComponentModel\Component::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 23

Deprecated: Return type of Nette\ComponentModel\Component::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/samsonasik/www/rector-nette/stubs/Nette/ComponentModel/Component.php on line 28
```