### PR TITLE
[Test] Revert ContextGetByTypeToConstructorInjectionRector test for use existing property with same Object Type

### DIFF
--- a/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/existing_constructor_param.php.inc
+++ b/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/existing_constructor_param.php.inc
@@ -47,14 +47,14 @@ class ExistingConstructorParam
      */
     private $someInterfaceToInject;
 
-    public function __construct(ISomeInterfaceToInject $someInterfaceToInject, private \Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Source\ISomeInterfaceToInject $someInterfaceToInject2)
+    public function __construct(ISomeInterfaceToInject $someInterfaceToInject)
     {
         $this->someInterfaceToInject = $someInterfaceToInject;
     }
 
     public function run()
     {
-        $someTypeToInject = $this->someInterfaceToInject2;
+        $someTypeToInject = $this->someInterfaceToInject;
     }
 }
 


### PR DESCRIPTION
Revert https://github.com/rectorphp/rector-nette/pull/57 due to use only increment when different object update on https://github.com/rectorphp/rector-symfony/pull/120