### PR TITLE
[Nette] Update to nette/neon 3.3.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.1",
         "ext-xml": "*",
-        "nette/neon": "^3.3.2",
+        "nette/neon": "^3.3.3",
         "rector/rector-phpunit": "^0.11.15",
         "symplify/vendor-patches": "^10.0",
         "symfony/string": "^6.0"

--- a/packages/NeonParser/NeonNodeTraverser.php
+++ b/packages/NeonParser/NeonNodeTraverser.php
@@ -54,7 +54,7 @@ final class NeonNodeTraverser
             }
 
             // traverse all children
-            foreach ($node->getSubNodes() as $subnode) {
+            foreach ($node as $subnode) {
                 $this->traverse($subnode);
             }
         }


### PR DESCRIPTION
Fix to avoid error: 

```bash
1) Rector\Nette\Tests\Rector\Neon\RenameMethodNeonRector\RenameMethodNeonRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Error: Call to undefined method Nette\Neon\Node\BlockArrayNode::getSubNodes()
```

- [x] Update to nette/neon ^3.3.3
- [x] Replace $node->getSubNodes() to directly use $node on loop.