### PR TITLE
Temporary pin nette/neon to 3.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.1",
         "ext-xml": "*",
-        "nette/neon": "^3.3.2",
+        "nette/neon": "3.3.2",
         "rector/rector-phpunit": "^0.11.15",
         "symplify/vendor-patches": "^10.0",
         "symfony/string": "^6.0"


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-src/pull/1917#issuecomment-1063745643
ref https://github.com/rectorphp/rector-nette/pull/59

can't be resolved by just change dependency and loop usage, so pin nette/neon to 3.3.2 for now.